### PR TITLE
Refactor(base): Ignore missing MANAGE_MESSAGES permission (#50)

### DIFF
--- a/bin/Embeds.js
+++ b/bin/Embeds.js
@@ -2,11 +2,11 @@
 
 Object.defineProperty(exports, "__esModule", {
   value: !0
-});
+}), exports.Embeds = void 0;
 
 const r = require("discord.js"), t = require("./base");
 
-exports.Embeds = class extends t.PaginationEmbed {
+class s extends t.PaginationEmbed {
   get currentEmbed() {
     return this.array[this.page - 1];
   }
@@ -28,7 +28,7 @@ exports.Embeds = class extends t.PaginationEmbed {
     return this.pages = this.array.length, await this._verify(), this._loadList();
   }
   setArray(t) {
-    if (!Array.isArray(t) || !Boolean(t.length)) throw new TypeError("Cannot invoke Embeds class without a valid array to paginate.");
+    if (!(Array.isArray(t) && Boolean(t.length))) throw new TypeError("Cannot invoke Embeds class without a valid array to paginate.");
     for (const [s, e] of t.entries()) {
       if (!Boolean(e) || e.constructor !== Object || !Object.keys(e).length) {
         if (e instanceof r.MessageEmbed) continue;
@@ -90,7 +90,7 @@ exports.Embeds = class extends t.PaginationEmbed {
   }
   toJSON() {
     if (!this.array) throw new TypeError("this.array must be set first.");
-    return this.array.map(r => r.toJSON());
+    return this.array.map((r => r.toJSON()));
   }
   async _loadList(t = !0) {
     this.listenerCount("pageUpdate") && this.emit("pageUpdate");
@@ -101,4 +101,6 @@ exports.Embeds = class extends t.PaginationEmbed {
       embed: s
     }), super._loadList(t);
   }
-};
+}
+
+exports.Embeds = s;

--- a/bin/FieldsEmbed.js
+++ b/bin/FieldsEmbed.js
@@ -2,13 +2,13 @@
 
 Object.defineProperty(exports, "__esModule", {
   value: !0
-});
+}), exports.FieldsEmbed = void 0;
 
 const e = require("discord.js"), t = require("./base");
 
-exports.FieldsEmbed = class extends t.PaginationEmbed {
+class s extends t.PaginationEmbed {
   constructor() {
-    super(), this.elementsPerPage = 10, this.embed = new e.MessageEmbed();
+    super(), this.elementsPerPage = 10, this.embed = new e.MessageEmbed;
   }
   get elementList() {
     const e = (this.page - 1) * this.elementsPerPage, t = e + this.elementsPerPage;
@@ -19,7 +19,7 @@ exports.FieldsEmbed = class extends t.PaginationEmbed {
     const e = this.embed.fields;
     this.embed.fields = [];
     for (const t of e) "function" == typeof t.value ? this.formatField(t.name, t.value, t.inline) : this.embed.addField(t.name, t.value, t.inline);
-    if (!this.embed.fields.filter(e => "function" == typeof e.value).length) throw new Error("Cannot invoke FieldsEmbed class without at least one formatted field to paginate.");
+    if (!this.embed.fields.filter((e => "function" == typeof e.value)).length) throw new Error("Cannot invoke FieldsEmbed class without at least one formatted field to paginate.");
     return this._loadList();
   }
   formatField(e, t, s = !0) {
@@ -49,4 +49,6 @@ exports.FieldsEmbed = class extends t.PaginationEmbed {
       embed: t
     }), super._loadList(e);
   }
-};
+}
+
+exports.FieldsEmbed = s;

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,9 +1,19 @@
 "use strict";
 
-function e(e) {
-  for (var r in e) exports.hasOwnProperty(r) || (exports[r] = e[r]);
-}
+var e = this && this.__createBinding || (Object.create ? function(e, r, t, i) {
+  void 0 === i && (i = t), Object.defineProperty(e, i, {
+    enumerable: !0,
+    get: function() {
+      return r[t];
+    }
+  });
+} : function(e, r, t, i) {
+  void 0 === i && (i = t), e[i] = r[t];
+}), r = this && this.__exportStar || function(r, t) {
+  for (var i in r) "default" === i || t.hasOwnProperty(i) || e(t, r, i);
+};
 
 Object.defineProperty(exports, "__esModule", {
   value: !0
-}), e(require("./Embeds")), e(require("./FieldsEmbed")), e(require("./base")), exports.version = require("../package.json").version;
+}), exports.version = void 0, r(require("./Embeds"), exports), r(require("./FieldsEmbed"), exports), 
+r(require("./base"), exports), exports.version = require("../package.json").version;


### PR DESCRIPTION
* * 🔧 The permission to manage messages is no longer necessary, now what you do first is verify that if you have the permission it will proceed to perform functions such as: delete user reactions, delete promt messages (from the user) and if the bot does not have the permission to manage messages will ignore those functions but the embed will continue to perform the same functions without problems.

* * 🔧 Rebuilt bin folder.